### PR TITLE
修改onSuccess 回调为公开函数

### DIFF
--- a/app/src/main/java/cn/finalteam/okhttpfinal/sample/DownloadActivity.java
+++ b/app/src/main/java/cn/finalteam/okhttpfinal/sample/DownloadActivity.java
@@ -52,8 +52,8 @@ public class DownloadActivity extends BaseActivity {
 
     @OnClick(R.id.btn_download)
     public void download() {
-        String url = "http://219.128.78.33/apk.r1.market.hiapk.com/data/upload/2015/05_20/14/com.speedsoftware.rootexplorer_140220.apk";
-        HttpRequest.download(url, new File("/sdcard/rootexplorer_140220.apk"), new FileDownloadCallback() {
+        String url = "http://www.bus365.com/public/phoneClient/BUS365.apk";
+        HttpRequest.download(url, new File("/sdcard/BUS365.apk"), new FileDownloadCallback() {
             @Override public void onStart() {
                 super.onStart();
             }

--- a/app/src/main/java/cn/finalteam/okhttpfinal/sample/HttpRequestCallbackJsonActivity.java
+++ b/app/src/main/java/cn/finalteam/okhttpfinal/sample/HttpRequestCallbackJsonActivity.java
@@ -53,7 +53,7 @@ public class HttpRequestCallbackJsonActivity extends BaseActivity {
         params.addFormDataPart("limit", 12);
         HttpRequest.post(Api.NEW_GAME, params, new JsonHttpRequestCallback() {
             @Override
-            protected void onSuccess(JSONObject jsonObject) {
+            public void onSuccess(JSONObject jsonObject) {
                 super.onSuccess(jsonObject);
                 mTvResult.setText(JsonFormatUtils.formatJson(jsonObject.toJSONString()));
             }

--- a/app/src/main/java/cn/finalteam/okhttpfinal/sample/HttpRequestCallbackStringActivity.java
+++ b/app/src/main/java/cn/finalteam/okhttpfinal/sample/HttpRequestCallbackStringActivity.java
@@ -52,7 +52,7 @@ public class HttpRequestCallbackStringActivity extends BaseActivity {
         params.addFormDataPart("limit", 12);
         HttpRequest.post(Api.NEW_GAME, params, new StringHttpRequestCallback() {
             @Override
-            protected void onSuccess(String s) {
+            public void onSuccess(String s) {
                 super.onSuccess(s);
                 mTvResult.setText(JsonFormatUtils.formatJson(s));
             }

--- a/app/src/main/java/cn/finalteam/okhttpfinal/sample/IApplication.java
+++ b/app/src/main/java/cn/finalteam/okhttpfinal/sample/IApplication.java
@@ -64,6 +64,7 @@ public class IApplication extends Application {
                 .setDebug(true);
 //        addHttps(builder);
         OkHttpFinal.getInstance().init(builder.build());
+        OkHttpFinal.getInstance().updateCommonHeader("Accept-Encoding", "identity");
     }
 
 

--- a/app/src/main/java/cn/finalteam/okhttpfinal/sample/http/MyBaseHttpRequestCallback.java
+++ b/app/src/main/java/cn/finalteam/okhttpfinal/sample/http/MyBaseHttpRequestCallback.java
@@ -11,7 +11,7 @@ import cn.finalteam.okhttpfinal.sample.http.model.BaseApiResponse;
 public class MyBaseHttpRequestCallback<T extends BaseApiResponse> extends BaseHttpRequestCallback<T>{
 
     @Override
-    protected void onSuccess(T t) {
+    public void onSuccess(T t) {
         int code = t.getCode();
         if ( code == 1 ) {
             onLogicSuccess(t);


### PR DESCRIPTION
建议把onSucess 设为公开函数，这样有利于android 代码开发时的分层！比如在界面层返回的是一个对象，这样可以把网络访问层的代码单独放置一层请求返回的是StringRequestCallback,但是通过Json处理后转为对象，就可以在成功的时候，直接用界面层传过来的其他回调指针，又可以回到UI层处理！代码写出来更清晰逻辑！
